### PR TITLE
Added gz files to be ingnored along with md and vault encrypted files

### DIFF
--- a/src/ansiblemdgen/AutoDocumenterBase.py
+++ b/src/ansiblemdgen/AutoDocumenterBase.py
@@ -28,8 +28,8 @@ class WriterBase:
             relPath = dirpath.replace(directory,"")
 
             for filename in filenames:
-                #ignore any existing md files and vault encrypted files
-                if not filename.endswith('.md') and self.isFileVaultEncrypted(dirpath, filename) is False:
+                #ignore any existing md files, archive and vault encrypted files
+                if not filename.endswith('.md') and not filename.endswith('.gz') and self.isFileVaultEncrypted(dirpath, filename) is False:
                         self.createMDFile(dirpath, filename, output_directory+"/"+relPath)
 
     def iterateOnCombinations(self, directory, combinations, output_directory):


### PR DESCRIPTION
This PR is fining the following issue: https://github.com/murphypetercl/ansible-mdgen/issues/33
Maybe there is more elegant way to build the list of files to be ignored by the tool.

Local testing went good.